### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/SpannedToAnnotatedString/build.gradle.kts
+++ b/SpannedToAnnotatedString/build.gradle.kts
@@ -42,12 +42,11 @@ dependencies {
 
     implementation("androidx.core:core-ktx:1.9.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
-    implementation("com.google.android.material:material:1.9.0")
     implementation(platform("androidx.compose:compose-bom:2023.03.00"))
+    implementation("androidx.compose.foundation:foundation")
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
-    implementation("androidx.compose.material3:material3")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")


### PR DESCRIPTION
The library is using some material dependencies that are not needed at all. Only the foundation dependency is needed to be added.

Cleaning up some dependencies will improve the possible conflicts when the library is integrated in different projects.